### PR TITLE
Refactor metrics only done

### DIFF
--- a/jira_api.go
+++ b/jira_api.go
@@ -128,6 +128,16 @@ func countWeekendDays(start time.Time, end time.Time) int {
         return weekendDays
 }
 
+func subtractDatesRemovingWeekends (start time.Time, end time.Time) time.Duration {
+    statusChangeDuration := end.Sub(start) 
+    weekendDaysBetweenDates := countWeekendDays(start, end)
+    if (weekendDaysBetweenDates > 0) {
+        updatedTotalSeconds := statusChangeDuration.Seconds() - float64(60 * 60 * 24 * weekendDaysBetweenDates)    
+        statusChangeDuration = time.Duration(updatedTotalSeconds)*time.Second
+    }
+    return statusChangeDuration
+}
+
 func formatColumns(columns []string) string {
     str := ""
 

--- a/jira_board.cfg
+++ b/jira_board.cfg
@@ -1,7 +1,7 @@
 {
-	"Project"    : "YOK",
-	"OpenStatus" : ["ABERTA", "BACKLOG", "PREPARADO", "IN PROGRESS"],
-	"WipStatus"  : ["PLANEJAMENTO DE TESTES", "DEV", "DEV DONE", "STG", "STG DONE", "QA", "QA DONE", "QA TESTS", "DELIVERY"],
-	"IdleStatus" : ["DEV DONE", "STG DONE", "QA DONE"],
-	"DoneStatus" : ["RESOLVIDA"]
+	"Project"    : "MLG",
+	"OpenStatus" : ["TO DO"],
+	"WipStatus"  : ["EM DESENVOLVIMENTO","CODE REVIEW","TESTES STG","TESTES QA"],
+	"IdleStatus" : ["DEPENDENCIA EXTERNA","TESTES QA - DONE", "TESTES STG - DONE", "CODE REVIEW DONE", "DESENVOLVIMENTO-DONE"],
+	"DoneStatus" : ["DONE"]
 }

--- a/jira_kanban_metrics.go
+++ b/jira_kanban_metrics.go
@@ -55,7 +55,7 @@ func processCommandLineParameters() CLParameters {
 }
 
 func extractMonthlyThroughput(parameters CLParameters, auth Auth, boardCfg BoardCfg) int {
-    troughputSearch := fmt.Sprintf("project = '%v' AND issuetype != Epic AND status CHANGED TO %v DURING('%v', '%v')", 
+    troughputSearch := fmt.Sprintf("project = '%v' AND issuetype != Epic AND status CHANGED TO %v DURING('%v', '%v')",
                                    boardCfg.Project, formatColumns(boardCfg.DoneStatus), formatJiraDate(parameters.StartDate), formatJiraDate(parameters.EndDate))
 
     if parameters.Debug {
@@ -72,9 +72,9 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
     startDate := formatJiraDate(parameters.StartDate)
     endDate := formatJiraDate(parameters.EndDate)
 
-    wipSearch := fmt.Sprintf("project = '%v' AND  issuetype != Epic " + 
-                             "AND (status CHANGED TO %v DURING('%v', '%v'))",                              
-                             boardCfg.Project, 
+    wipSearch := fmt.Sprintf("project = '%v' AND  issuetype != Epic " +
+                             "AND (status CHANGED TO %v DURING('%v', '%v'))",
+                             boardCfg.Project,
                              formatColumns(boardCfg.DoneStatus), startDate, endDate)
 
     if parameters.Debug {
@@ -92,15 +92,11 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
 
     var totalDurationByStatusMap map[string]time.Duration = make(map[string]time.Duration) // Duration by status type
     var totalDurationByStatusTypeMap map[string]time.Duration = make(map[string]time.Duration) // Duration by status type
-    var totalDuration time.Duration // total duration of all issues processed by the script
+    var totalDuration time.Duration // Total duration of all issues processed by the script (All status)
+    var wipDuration time.Duration // WIP duration of all issues (WIP/Idle)
 
-    var issueDetailsMap map[string]IssueDetails = make(map[string]IssueDetails)    
-    var issueDetailsMapByType map[string]IssueDetails = make(map[string]IssueDetails)    
-
-    var issueDetailsMapByType2 map[string][]IssueDetails = make(map[string][]IssueDetails)    
-
-    
-
+    var issueDetailsMap map[string]IssueDetails = make(map[string]IssueDetails)
+    var issueDetailsMapByType map[string][]IssueDetails = make(map[string][]IssueDetails)
 
     // Transitions on the board: Issue -> Changelog -> Histories -> Items -> Field:Status
     for _, issue := range result.Issues {
@@ -114,13 +110,12 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
         var issueDurationByStatusTypeMap map[string]time.Duration = make(map[string]time.Duration)  // Total duration [value] by status [key]
 
         var lastToStatus string
-        
         var transitionToWipDate time.Time
 
         var issueCreatedDate time.Time = parseJiraTime(issue.Fields.Created)
         var lastFromStatusCreationDate time.Time = issueCreatedDate
-        
-        if parameters.DebugVerbose {                 
+
+        if parameters.DebugVerbose {
             fmt.Printf(TERM_COLOR_YELLOW + "\nIssue Jira: %v | VERBOSE DEBUG START \n", issue.Key)
         }
 
@@ -145,10 +140,10 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
                     }
 
                     // Calculating status transition duration
-                    statusChangeDuration := statusChangeTime.Sub(lastFromStatusCreationDate) 
+                    statusChangeDuration := statusChangeTime.Sub(lastFromStatusCreationDate)
                     weekendDaysBetweenDates := countWeekendDays(lastFromStatusCreationDate, statusChangeTime)
                     if (weekendDaysBetweenDates > 0) {
-                        updatedTotalSeconds := statusChangeDuration.Seconds() - float64(60 * 60 * 24 * weekendDaysBetweenDates)    
+                        updatedTotalSeconds := statusChangeDuration.Seconds() - float64(60 * 60 * 24 * weekendDaysBetweenDates)
                         statusChangeDuration = time.Duration(updatedTotalSeconds)*time.Second
                         if parameters.DebugVerbose {
                             fmt.Printf(TERM_COLOR_RED + "Removing weekend days [%v] from Status [%v] \n" + TERM_COLOR_YELLOW, weekendDaysBetweenDates, item.Fromstring)
@@ -156,14 +151,14 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
                     }
 
                     if parameters.DebugVerbose {
-                        printDebugIssueTransition (parameters.DebugVerbose, statusChangeTime, lastFromStatusCreationDate, statusChangeDuration, item.Fromstring, item.Tostring) 
+                        printDebugIssueTransition (parameters.DebugVerbose, statusChangeTime, lastFromStatusCreationDate, statusChangeDuration, item.Fromstring, item.Tostring)
                     }
-                    
+
                     // Group total minutes by status, considering this status transition
                     durationByStatusMap[item.Fromstring] = durationByStatusMap[item.Fromstring] + int64(statusChangeDuration.Minutes())
                     issueDurationByStatusMap[item.Fromstring] = issueDurationByStatusMap[item.Fromstring] + statusChangeDuration
 
-                    //update vars for next interation
+                    // Update vars for next interation
                     lastToStatus = item.Tostring
                     lastFromStatusCreationDate = statusChangeTime
 
@@ -177,40 +172,27 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
         if (lastFromStatusCreationDate.Before(parameters.EndDate) && !containsStatus(boardCfg.DoneStatus, lastToStatus)) {
             statusChangeDuration := parameters.EndDate.Sub(lastFromStatusCreationDate)
 
-            // Group total minutes by status, considering this status transition          
+            // Group total minutes by status, considering this status transition
             durationByStatusMap[lastToStatus] = durationByStatusMap[lastToStatus] + int64(statusChangeDuration.Minutes())
             issueDurationByStatusMap[lastToStatus] = issueDurationByStatusMap[lastToStatus] + statusChangeDuration
-            
-            // print debug
-            if parameters.Debug {                
+
+            // Print debug
+            if parameters.Debug {
                 fmt.Printf(TERM_COLOR_RED + "Status current in development, considering endDate [%v] \n" + TERM_COLOR_WHITE, formatBrDateWithTime(parameters.EndDate))
-            }   
-            
-            printDebugIssueTransition (parameters.DebugVerbose, parameters.EndDate, lastFromStatusCreationDate, statusChangeDuration, lastToStatus, "None") 
+            }
+
+            printDebugIssueTransition (parameters.DebugVerbose, parameters.EndDate, lastFromStatusCreationDate, statusChangeDuration, lastToStatus, "None")
         }
 
         // Calculate the duration of all status
         if parameters.Debug {
             fmt.Printf(TERM_COLOR_BLUE + "\nIssue Jira: %v\n" + TERM_COLOR_WHITE, issue.Key)
-        }   
-
-        var issueTotalDuration time.Duration
-        for k, v := range issueDurationByStatusMap {  
-            issueTotalDuration += v 
-            totalDuration += v
-
-            // adding it to the total count
-            totalDurationByStatusMap[k] += v
-
-            if parameters.Debug {
-                fmt.Printf("Status [%v] time in [%v] \n", k, v)
-            }   
         }
 
-
-        // grouping by status type configured in board.cfg
+        var issueTotalDuration time.Duration
         var statusType string
-        for k, v := range issueDurationByStatusMap {        
+
+        for k, v := range issueDurationByStatusMap {
             if (containsStatus(boardCfg.OpenStatus, k)) {
                 statusType = "Open";
             } else if (containsStatus(boardCfg.WipStatus, k)) {
@@ -220,30 +202,43 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
             } else if (containsStatus(boardCfg.DoneStatus, k)) {
                 statusType = "Done";
             } else {
-                fmt.Printf("%v = not mapped in board.cfg, please update it.\n", k)
+                fmt.Printf("Status %v not mapped in board.cfg, please update it.\n", k)
                 continue
+            }
+
+            totalDuration += v
+
+            // Adding it to the total count only if in WIP/Idle
+            if (statusType == "Wip" || statusType == "Idle") {
+                wipDuration += v
+                issueTotalDuration += v
+                totalDurationByStatusMap[k] += v
+             }
+
+            if parameters.Debug {
+                fmt.Printf("Status [%v] time in [%v] \n", k, v)
             }
 
             issueDurationByStatusTypeMap[statusType] = issueDurationByStatusTypeMap[statusType] + v
         }
 
         // Calculating WIP days
-        issueDurationTotalWip := issueDurationByStatusTypeMap["Wip"]+issueDurationByStatusTypeMap["Idle"]
-        issueWipDays := int(issueDurationTotalWip.Hours())/24
+        issueDurationTotalWip := issueDurationByStatusTypeMap["Wip"] + issueDurationByStatusTypeMap["Idle"]
+        issueWipDays := int(issueDurationTotalWip.Hours()) / 24
         if (issueWipDays == 0) {
             issueWipDays = 1
         }
-        totalWipDays += issueWipDays 
+        totalWipDays += issueWipDays
 
         // Verify if the last transition is to a resolved status
         if (containsStatus(boardCfg.DoneStatus, lastToStatus)) {
             resolved = true
 
             // Double check if the wip is being calculated correct, it's not used for anything else
-            issueTotalWip := subtractDatesRemovingWeekends(transitionToWipDate, lastFromStatusCreationDate)    
+            issueTotalWip := subtractDatesRemovingWeekends(transitionToWipDate, lastFromStatusCreationDate)
             wipDiffBetweenCalcMethods := issueDurationTotalWip-issueTotalWip
             if (parameters.Debug && (wipDiffBetweenCalcMethods.Hours() > 1 || wipDiffBetweenCalcMethods.Hours() < -1)) {
-                fmt.Printf(TERM_COLOR_RED + "Issue has some strange status transition. Please check it!!! \n" + TERM_COLOR_WHITE)                        
+                fmt.Printf(TERM_COLOR_RED + "Issue has some strange status transition. Please check it!!! \n" + TERM_COLOR_WHITE)
             }
         }
 
@@ -251,23 +246,23 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
             issueTypeMap[issue.Fields.Issuetype.Name]++
         }
 
-        // calculating percentage by status type configured in board.cfg
+        // Calculating percentage by status type configured in board.cfg
         for k, v := range issueDurationByStatusTypeMap {
-            statusPercent := float64(v * 100) / float64(issueTotalDuration) 
+            statusPercent := float64(v * 100) / float64(issueTotalDuration)
 
-            // adding it to the total count
+            // Adding it to the total count
             totalDurationByStatusTypeMap[k] += v
 
-            // print details if in debug mode
+            // Print details if in debug mode
             if parameters.Debug {
                 fmt.Printf("%v = %.2f%% [%v] \n", k, statusPercent, v)
             }
         }
 
-        // print status transition details by issue if in debug Mode
+        // Print status transition details by issue if in debug Mode
         if parameters.DebugVerbose {
-            fmt.Print("\n>Status Transition Details\n")   
-            for k, v := range issueDurationByStatusMap {    
+            fmt.Print("\n>Status Transition Details\n")
+            for k, v := range issueDurationByStatusMap {
                 statusPercent := float64(v * 100) / float64(issueTotalDuration)
                 fmt.Printf("%v = %.2f%% [%v] \n", k, statusPercent, v)
             }
@@ -281,27 +276,25 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
         issueDetails.EpicLink = epicLink
         issueDetails.IssueType = issue.Fields.Issuetype.Name
         issueDetails.Resolved = resolved
-    
-        issueDetailsMap[issueDetails.Name] = issueDetails 
-        issueDetailsMapByType[issueDetails.IssueType] = issueDetails
 
-        issueArray := issueDetailsMapByType2[issueDetails.IssueType]
+        issueDetailsMap[issueDetails.Name] = issueDetails
+
+        issueArray := issueDetailsMapByType[issueDetails.IssueType]
         issueArray = append(issueArray, issueDetails)
-        issueDetailsMapByType2[issueDetails.IssueType] = issueArray
+        issueDetailsMapByType[issueDetails.IssueType] = issueArray
     }
 
-    
     lastType := ""
-    for issueType, issueDetailsArray := range issueDetailsMapByType2 { 
+    for issueType, issueDetailsArray := range issueDetailsMapByType {
         if (lastType != issueType) {
-            lastType = issueType    
-            fmt.Printf("\n>> %v\n", issueType)        
+            lastType = issueType
+            fmt.Printf("\n>> %v\n", issueType)
         }
 
         var wipDays[]float64
         totalWipDaysByIssueType := 0
         for _, issueDetails := range issueDetailsArray {
-            fmt.Printf(TERM_COLOR_BLUE + "Issue Jira: %v | %v | Start: %v| End: %v | WIP days: %v | ", issueDetails.Name, issueDetails.Summary, 
+            fmt.Printf(TERM_COLOR_BLUE + "Issue Jira: %v | %v | Start: %v| End: %v | WIP days: %v | ", issueDetails.Name, issueDetails.Summary,
             formatBrDate(issueDetails.StartDate), formatBrDate(issueDetails.EndDate), issueDetails.WIP)
 
             if issueDetails.EpicLink != "" {
@@ -321,17 +314,17 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
         totalWipAverageByIssueType := float64(totalWipDaysByIssueType / len(issueDetailsArray))
         fmt.Printf("Average lead time: %v\n", totalWipAverageByIssueType)
         fmt.Printf("Median lead time: %v\n", median(wipDays))
-    }    
+    }
 
     fmt.Printf("\n> Average by Status\n")
     for k, v := range totalDurationByStatusMap {
-        statusPercent := float64(v * 100) / float64(totalDuration) 
+        statusPercent := float64(v * 100) / float64(wipDuration)
         fmt.Printf("%v = %.2f%% [%v] \n", k, statusPercent, v)
     }
 
     fmt.Printf("\n> Average by Status Type\n")
     for k, v := range totalDurationByStatusTypeMap {
-        statusPercent := float64(v * 100) / float64(totalDuration) 
+        statusPercent := float64(v * 100) / float64(totalDuration)
         fmt.Printf("%v = %.2f%% [%v] \n", k, statusPercent, v)
     }
 
@@ -354,8 +347,8 @@ func extractMetrics(parameters CLParameters, auth Auth, boardCfg BoardCfg) {
 
     fmt.Printf("\n> Lead time: %.2f days\n", float64(totalWipDays) / float64(throughtputMonthly))
 
-    fmt.Printf("Data for scaterplot\n")
-    for _, v := range issueDetailsMap { 
+    fmt.Printf("\n> Data for scaterplot\n")
+    for _, v := range issueDetailsMap {
         fmt.Printf("%v;%v;%v;%v;%v;%v\n", v.Name, formatBrDate(v.StartDate), formatBrDate(v.EndDate), v.WIP, v.EpicLink, v.IssueType)
     }
 }
@@ -367,7 +360,7 @@ func main() {
 
     boardCfg := loadBoardCfg()
 
-    fmt.Printf("Extracting Kanban metrics from project %v, %v to %v\n\n", 
+    fmt.Printf("Extracting Kanban metrics from project %v, %v to %v\n\n",
         boardCfg.Project, formatJiraDate(parameters.StartDate), formatJiraDate(parameters.EndDate))
 
     extractMetrics(parameters, auth, boardCfg)
@@ -376,14 +369,11 @@ func main() {
 func printDebugIssueTransition (isDebug bool, statusChangeTime time.Time, statusChangeTimeStart time.Time, statusChangeDuration time.Duration, statusFrom string, statusTo string) {
 
     if isDebug {
-    
         // Calculating days, hours and minutes of this status transition
-        statusChangeDurationDays := int(statusChangeDuration.Hours())/int(24)
-        statusChangeDurationHours := int(statusChangeDuration.Hours() - float64(statusChangeDurationDays*int(24)))
-        statusChangeDurationMinutes := int(statusChangeDuration.Minutes()- float64((statusChangeDurationDays*24*60)+(statusChangeDurationHours*int(60))))
+        statusChangeDurationDays := int(statusChangeDuration.Hours()) / int(24)
+        statusChangeDurationHours := int(statusChangeDuration.Hours() - float64(statusChangeDurationDays * int(24)))
+        statusChangeDurationMinutes := int(statusChangeDuration.Minutes() - float64((statusChangeDurationDays * 24 * 60) + (statusChangeDurationHours * int(60))))
 
-        // printing this data
-        // fmt.Printf("%v -> %v (%v)\n", statusFrom, statusTo, formatJiraDate(statusChangeTime))
         fmt.Printf("%v -> %v (%v)\n", statusFrom, statusTo, formatBrDateWithTime(statusChangeTime))
         fmt.Printf("Status [%v] Time in Status [%vd %vh %vm] \n", statusFrom, statusChangeDurationDays, statusChangeDurationHours, statusChangeDurationMinutes)
         fmt.Printf("Debug [%v] - [%v] = [%v] \n\n", formatBrDateWithTime(statusChangeTime), formatBrDateWithTime(statusChangeTimeStart), statusChangeDuration)

--- a/parsing.go
+++ b/parsing.go
@@ -40,6 +40,12 @@ func formatBrDate(date time.Time) string {
     return date.Format(brDateFormat)
 }
 
+func formatBrDateWithTime(date time.Time) string {
+    const brDateFormat = "02/01/2006 15:04"
+
+    return date.Format(brDateFormat)
+}
+
 func stripHours(t time.Time) time.Time {
     return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }

--- a/struct.go
+++ b/struct.go
@@ -10,6 +10,7 @@ type CLParameters struct {
     EndDate time.Time
     JiraUrl string
     Debug bool
+    DebugVerbose bool
 }
 
 type BoardCfg struct {

--- a/struct.go
+++ b/struct.go
@@ -21,6 +21,17 @@ type BoardCfg struct {
     DoneStatus []string
 }
 
+type IssueDetails struct {
+    Name string
+    Summary string
+    StartDate time.Time
+    EndDate time.Time
+    WIP int
+    EpicLink string
+    IssueType string 
+    Resolved bool
+}
+
 type Auth struct {
     Session struct {
         Name string `json:"name"`


### PR DESCRIPTION
I've been working on showing just the done tasks, because it's show the real result of the team. The task duration does not filter only the period passed to the script, now it's shown the total time of the task, including status transitions happened before the start date, leading to real lead times, that are bigger than the filltered period.